### PR TITLE
For You page organizations' names made scrollable horizontally

### DIFF
--- a/EventsManager/Views/EventTableHeaderFooterView.swift
+++ b/EventsManager/Views/EventTableHeaderFooterView.swift
@@ -16,9 +16,10 @@ class EventTableHeaderFooterView: UITableViewHeaderFooterView {
     let sideMargins: CGFloat = 15
     let bottomMargins: CGFloat = 5
     let titleFontSize: CGFloat = 17
+    let titleViewSize: CGFloat = 20
     let buttonFontSize: CGFloat = 14
-
-    var title = UILabel()
+    
+    var title = UITextView()
     let editButton = UIButton()
 
     required init?(coder aDecoder: NSCoder) {super.init(coder: aDecoder)}
@@ -32,14 +33,32 @@ class EventTableHeaderFooterView: UITableViewHeaderFooterView {
         editButton.setTitleColor(UIColor.gray, for: .normal)
         editButton.titleLabel?.font = UIFont(name: "SFProText-Regular", size: buttonFontSize)
 
+
+        title.backgroundColor = UIColor.clear
+
+        title.text = "test"
+
         title.font = UIFont(name: "SFProText-Bold", size: titleFontSize)
         title.textColor = UIColor(named: "primaryPink")
-
+        title.textContainer.lineFragmentPadding = 0
+        title.isEditable = false
+        
+        title.contentInset = .zero
+        title.contentInsetAdjustmentBehavior = .never
+        
+        title.textContainerInset = .zero
+        title.textContainer.lineFragmentPadding = 0
+        title.sizeToFit()
+        title.layoutManager.usesFontLeading = false
+        
         self.addSubview(title)
         self.addSubview(editButton)
 
         title.snp.makeConstraints { make in
             make.left.equalTo(self).offset(sideMargins)
+            make.right.equalTo(self)
+            // set UITextView's height equal to the contentSize to disable vertical scrolling
+            make.height.equalTo(title.contentSize.height)
             make.bottom.equalTo(self)
         }
 

--- a/EventsManager/Views/EventTableHeaderFooterView.swift
+++ b/EventsManager/Views/EventTableHeaderFooterView.swift
@@ -15,11 +15,12 @@ class EventTableHeaderFooterView: UITableViewHeaderFooterView {
 
     let sideMargins: CGFloat = 15
     let bottomMargins: CGFloat = 5
+    let topMargins: CGFloat = 12
     let titleFontSize: CGFloat = 17
-    let titleViewSize: CGFloat = 20
     let buttonFontSize: CGFloat = 14
     
-    var title = UITextView()
+    var scrollable = UIScrollView()
+    var title = UILabel()
     let editButton = UIButton()
 
     required init?(coder aDecoder: NSCoder) {super.init(coder: aDecoder)}
@@ -32,36 +33,31 @@ class EventTableHeaderFooterView: UITableViewHeaderFooterView {
     func setLayouts() {
         editButton.setTitleColor(UIColor.gray, for: .normal)
         editButton.titleLabel?.font = UIFont(name: "SFProText-Regular", size: buttonFontSize)
-
-
-        title.backgroundColor = UIColor.clear
-
-        title.text = "test"
-
+        
         title.font = UIFont(name: "SFProText-Bold", size: titleFontSize)
         title.textColor = UIColor(named: "primaryPink")
-        title.textContainer.lineFragmentPadding = 0
-        title.isEditable = false
-        
-        title.contentInset = .zero
-        title.contentInsetAdjustmentBehavior = .never
-        
-        title.textContainerInset = .zero
-        title.textContainer.lineFragmentPadding = 0
-        title.sizeToFit()
-        title.layoutManager.usesFontLeading = false
-        title.isSelectable = false
-        title.isScrollEnabled = true
-        
-        self.addSubview(title)
-        self.addSubview(editButton)
+        title.textAlignment = .center
 
-        title.snp.makeConstraints { make in
-            make.left.equalTo(self).offset(sideMargins)
+        scrollable.backgroundColor = .clear
+        
+        self.addSubview(scrollable)
+        self.addSubview(editButton)
+        scrollable.addSubview(title)
+
+        scrollable.snp.makeConstraints { make in
+            make.left.equalTo(self)
             make.right.equalTo(self)
-            // set UITextView's height equal to the contentSize to disable vertical scrolling
-            make.height.equalTo(title.contentSize.height)
-            make.bottom.equalTo(self)
+
+            make.height.equalTo(scrollable.contentSize.height)
+            make.top.equalTo(self)
+            make.bottom.equalTo(self).offset(bottomMargins)
+        }
+        
+        title.snp.makeConstraints { make in
+            make.left.equalTo(scrollable).offset(sideMargins)
+            make.right.equalTo(scrollable)
+            make.top.equalTo(scrollable).offset(topMargins)
+            make.bottom.equalTo(scrollable)
         }
 
         editButton.snp.makeConstraints { make in

--- a/EventsManager/Views/EventTableHeaderFooterView.swift
+++ b/EventsManager/Views/EventTableHeaderFooterView.swift
@@ -50,6 +50,8 @@ class EventTableHeaderFooterView: UITableViewHeaderFooterView {
         title.textContainer.lineFragmentPadding = 0
         title.sizeToFit()
         title.layoutManager.usesFontLeading = false
+        title.isSelectable = false
+        title.isScrollEnabled = true
         
         self.addSubview(title)
         self.addSubview(editButton)


### PR DESCRIPTION
### Summary

This pull request makes the organization names scrollable, fixing the issue where names would be cut off when extending past the screen.

- Implemented UIScrollView to allow for horizontal scrolling
- Fixed the name getting cut off when its length was greater than the screen's width

### Test Plan

To test, I created Organization Names longer than the screen's width. 
I made sure vertical scrolling was disabled, and horizontal scrolling was enabled through setting constraints. 
For example, these screenshots show you can now scroll, and there is a horizontal scrolling bar.

### Notes
Subtle point: I had to add a topMargin constraint, when before there was a bottomMargin constraint. Without this constant added, the UIScrollView would allow for vertical scrolling.
<img width="355" alt="Screen Shot 2020-03-30 at 12 01 02 PM" src="https://user-images.githubusercontent.com/35770469/77936005-4491af00-7280-11ea-8417-84afa5b26f6e.png">
<img width="282" alt="Screen Shot 2020-03-30 at 12 01 11 PM" src="https://user-images.githubusercontent.com/35770469/77936013-46f40900-7280-11ea-9c59-bac91258e089.png">



