### PR TITLE
add firebase tracking for search and removed rows in for you that ha…

### DIFF
--- a/EventsManager/AppDelegate.swift
+++ b/EventsManager/AppDelegate.swift
@@ -62,16 +62,11 @@ class AppDelegate: UIResponder, UIApplicationDelegate, UNUserNotificationCenterD
         //log notifications that have been sent and are in the notification center (have not been clicked by the user)
         notificationCenter.getDeliveredNotifications(completionHandler: { notifications in
             for notification in notifications {
-                if notification.request.content.title == "Here is an event you may be interested in" {
-                    Analytics.logEvent("tailoredNotificationAppeared", parameters: [
-                        "description": notification.request.content
-                    ])
-                } else {
-                    Analytics.logEvent("notificationAppeared", parameters: [
-                        "description": notification.request.content
-                    ])
-                }
+                Analytics.logEvent("notificationAppeared", parameters: [
+                    "description": notification.request.content
+                ])
             }
+            
         })
 
         return true
@@ -80,15 +75,11 @@ class AppDelegate: UIResponder, UIApplicationDelegate, UNUserNotificationCenterD
     //track notifications that have been clicked
     func userNotificationCenter(_ center: UNUserNotificationCenter, didReceive response: UNNotificationResponse, withCompletionHandler completionHandler: @escaping () -> Void) {
 
-        if response.notification.request.content.title == "Here is an event you may be interested in" {
-            Analytics.logEvent("tailoredNotificationClicked", parameters: [
-                "description": response.notification.request.content
-            ])
-        } else {
+        
             Analytics.logEvent("notificationClicked", parameters: [
                 "description": response.notification.request.content
             ])
-        }
+        
 
         completionHandler()
     }

--- a/EventsManager/Utilities/UserData.swift
+++ b/EventsManager/Utilities/UserData.swift
@@ -254,7 +254,15 @@ class UserData {
             var recommendedLabelEventsPairs: [(String, [Event])] = []
             for (pk, _, type) in recommendedData {
                 let label = type == .organization ? "Based on \(AppData.getOrganization(by: pk, startLoading: {_ in }, endLoading: {}, noConnection: {}, updateData: false).name)" : "Based on #\(AppData.getTag(by: pk, startLoading: {_ in }, endLoading: {}, noConnection: {}, updateData: false).name)"
-                recommendedLabelEventsPairs.append((label, type == .organization ? AppData.getEventsAssociatedWith(organization: pk) : AppData.getEventsAssociatedWith(tag: pk)))
+                if type == .organization {
+                    if AppData.getEventsAssociatedWith(organization: pk).count > 0 {
+                        recommendedLabelEventsPairs.append((label, AppData.getEventsAssociatedWith(organization: pk)))
+                    }
+                } else {
+                    if AppData.getEventsAssociatedWith(tag: pk).count > 0 {
+                        recommendedLabelEventsPairs.append((label, AppData.getEventsAssociatedWith(tag: pk)))
+                    }
+                }
             }
             return recommendedLabelEventsPairs
         }

--- a/EventsManager/ViewControllers/EventDetailViewController.swift
+++ b/EventsManager/ViewControllers/EventDetailViewController.swift
@@ -592,7 +592,6 @@ class EventDetailViewController: UIViewController, UIScrollViewDelegate, UIGestu
                 Analytics.logEvent("bookmarked", parameters: [
                     "eventName": event?.eventName ?? ""
                     ])
-                print("got here")
                 if let event = event {
                     if !user.bookmarkedEvents.contains(event.id) {
                         user.bookmarkedEvents.append(event.id)

--- a/EventsManager/ViewControllers/EventsDiscoveryController.swift
+++ b/EventsManager/ViewControllers/EventsDiscoveryController.swift
@@ -155,13 +155,15 @@ class EventsDiscoveryController: UIViewController, UITableViewDelegate, UITableV
                     content: content, trigger: trigger)
 
         // Schedule the request with the system.
-        let notificationCenter = UNUserNotificationCenter.current()
-        notificationCenter.add(request) { (error) in
-           if error != nil {
-              // Handle any errors.
-           }
-        }
-        
+        let center = UNUserNotificationCenter.current()
+        center.getPendingNotificationRequests(completionHandler: { requests in
+            if !(requests.contains(request)) {
+                center.add(request, withCompletionHandler: { (_) in
+                })
+                Analytics.logEvent("weeklyNotificationAdded", parameters: [:])
+            }
+        })
+    }
 //        var dateComponents = DateComponents()
 //        dateComponents.calendar = Calendar.current
 //        let center = UNUserNotificationCenter.current()
@@ -185,7 +187,7 @@ class EventsDiscoveryController: UIViewController, UITableViewDelegate, UITableV
 //            }
 //        })
 
-    }
+    
 
     @objc func refresh(sender:AnyObject) {
         _ = AppData.getEvents(startLoading: GenericLoadingHelper.voidLoading(), endLoading: {

--- a/EventsManager/ViewControllers/EventsSearchViewController.swift
+++ b/EventsManager/ViewControllers/EventsSearchViewController.swift
@@ -6,6 +6,7 @@
 //
 
 import UIKit
+import Firebase
 
 class EventsSearchViewController: UIViewController, UISearchControllerDelegate, UITableViewDelegate, UITableViewDataSource, UISearchResultsUpdating, UISearchBarDelegate {
 
@@ -203,10 +204,12 @@ class EventsSearchViewController: UIViewController, UISearchControllerDelegate, 
     func tableView(_ tableView: UITableView, didSelectRowAt indexPath: IndexPath) {
         switch currentSearchScope {
             case .events:
+                Analytics.logEvent("clickedonEventWhileSearching", parameters: [:])
                 let detailsViewController = EventDetailViewController()
                 detailsViewController.configure(with: eventsOnDate[indexPath.section][indexPath.row].id)
                 navigationController?.pushViewController(detailsViewController, animated: true)
             case .organization:
+                Analytics.logEvent("clickedonOrgWhileSearching", parameters: [:])
                 let org = AppData.getOrganization(by: filteredOrganizations[indexPath.row].id, startLoading: {_ in }, endLoading: {}, noConnection: {}, updateData: false)
                 if org.email != "donotdisplay@cornell.edu" {
                     let orgViewController = OrganizationViewController()
@@ -214,7 +217,7 @@ class EventsSearchViewController: UIViewController, UISearchControllerDelegate, 
                     navigationController?.pushViewController(orgViewController, animated: true)
                 }
             case .tags:
-              //  GoogleAnalytics.trackEvent(category: "button click", action: "tag", label: "search pg")
+                Analytics.logEvent("clickedOnTagWhileSearching", parameters: [:])
                 let tagViewController = TagViewController()
                 tagViewController.setup(with: events, for: filteredTags[indexPath.row])
                 navigationController?.pushViewController(tagViewController, animated: true)
@@ -241,6 +244,7 @@ class EventsSearchViewController: UIViewController, UISearchControllerDelegate, 
     func isSearching() -> Bool {
         return searchController.isActive && !searchBarIsEmpty()
     }
+
 
     func searchBarIsEmpty() -> Bool {
         // Returns true if the text is empty or nil
@@ -294,6 +298,17 @@ class EventsSearchViewController: UIViewController, UISearchControllerDelegate, 
 
     func searchBar(_ searchBar: UISearchBar, selectedScopeButtonIndexDidChange selectedScope: Int) {
             filterContentForSearchText(searchBar.text!, scope: searchBar.scopeButtonTitles![selectedScope])
+    }
+    
+    func searchBarTextDidEndEditing(_ searchBar: UISearchBar) {
+        switch searchBar.selectedScopeButtonIndex {
+        case 0:
+            Analytics.logEvent("searchedForEvent", parameters: [:])
+        case 1:
+            Analytics.logEvent("searchedForOrg", parameters: [:])
+        default:
+            Analytics.logEvent("searchedForTag", parameters: [:])
+        }
     }
 
 }

--- a/EventsManager/ViewControllers/ForYouViewController.swift
+++ b/EventsManager/ViewControllers/ForYouViewController.swift
@@ -114,9 +114,6 @@ class ForYouViewController: UIViewController, UITableViewDelegate, UITableViewDa
                         if !(requests.contains(request)) {
                             center.add(request, withCompletionHandler: { (_) in
                             })
-                            Analytics.logEvent("tailoredNotificationAdded", parameters: [
-                                "notificationName": mostPopularEvent.eventName
-                            ])
                         }
                     })
                 }

--- a/EventsManager/ViewControllers/OnBoardingViewController.swift
+++ b/EventsManager/ViewControllers/OnBoardingViewController.swift
@@ -326,18 +326,15 @@ class OnBoardingViewController: UIViewController, UITableViewDelegate, UITableVi
     }
 
     func tableView(_ tableView: UITableView, didDeselectRowAt indexPath: IndexPath) {
-        print(checkedOrganizationIDs)
         switch currentOnBoardingProcess {
             case .chooseOrganization:
                 let selectedOrganizationID = filteredOrganizations[indexPath.row].id
-               // print(selectedOrganizationID)
                 checkedOrganizationIDs.remove(at: checkedOrganizationIDs.index(of: selectedOrganizationID)!)
                 user?.followingOrganizations.remove(at: (user?.followingOrganizations.index(of:selectedOrganizationID)!)!)
                 setNavigatorFowardButtonStatus()
             case .chooseTags:
                 let selectedTagID = filteredTags[indexPath.row].id
                 let selectedTagName = filteredTags[indexPath.row].name
-             //   print(selectedTagID)
                 checkedTags.remove(at: checkedTags.index(of: selectedTagID)!)
                 checkedTagNames.remove(at: checkedTagNames.index(of: selectedTagName)!)
                 user?.followingTags.remove(at: (user?.followingTags.index(of:selectedTagID)!)!)

--- a/EventsManager/ViewControllers/TabBarViewController.swift
+++ b/EventsManager/ViewControllers/TabBarViewController.swift
@@ -19,9 +19,6 @@ extension UIScrollView {
         } else {
             desiredOffset = CGPoint(x: 0, y: -navigHeight-5)
         }
-//        print(contentOffset.y)
-//        print(desiredOffset.y)
-//        print(Offset._offset)
         if contentOffset.y != Offset._offset {
             Offset._offset = desiredOffset.y //content
             setContentOffset(desiredOffset, animated: true)
@@ -104,9 +101,7 @@ class TabBarViewController: UITabBarController, UITabBarControllerDelegate {
             let navigVC = viewController as? UINavigationController
             let finalVC = navigVC?.viewControllers[0] as? MyProfileViewController
             finalVC?.tableView.scrollToTopMyProfile()
-            
         }
-        
     }
 
 }


### PR DESCRIPTION
Now, rows in the For You screen are only ones with events (no empty rows).
Also implemented Firebase tracking for when users search for events, organizations, and tags, and track if the user clicks on an event, org, or tag they searched for.

![IMG_180F0200F34C-1](https://user-images.githubusercontent.com/36087701/80552920-1a720080-8996-11ea-96d1-47d0de3a2d60.jpeg)
