### PR TITLE
Free Food Event Notification

### DIFF
--- a/EventsManager/AppDelegate.swift
+++ b/EventsManager/AppDelegate.swift
@@ -46,21 +46,21 @@ class AppDelegate: UIResponder, UIApplicationDelegate, UNUserNotificationCenterD
             window?.rootViewController = LoginViewController()
         }
         window?.makeKeyAndVisible()
+        if !UserData.didLogin() {
+            //free food alert
+            print("free food")
+            let alert = UIAlertController(title: "Don't miss out on events with free food!", message: "Enabling notifications allows us to notify you about events with free food coming up one day in advance.", preferredStyle: .alert)
+            alert.addAction(UIAlertAction(title: "OK", style: .default, handler: { _ in
+                self.notificationAuthorization()
+            }))
+            self.window?.rootViewController?.present(alert, animated: true, completion: nil)
+        }
 
         // Set global appearance attributes
         UITabBar.appearance().barTintColor = UIColor.white
         UINavigationBar.appearance().titleTextAttributes = [NSAttributedString.Key.font: UIFont(name: "SFProText-Bold", size: 19)!, NSAttributedString.Key.foregroundColor: UIColor(named: "primaryPink") ?? UIColor.red]
         UINavigationBar.appearance().largeTitleTextAttributes = [NSAttributedString.Key.font: UIFont(name: "SFProText-Bold", size: 32)!, NSAttributedString.Key.foregroundColor: UIColor(named: "primaryPink") ?? UIColor.red]
         window?.tintColor = UIColor(named: "primaryPink")
-        
-
-        //free food alert
-//        let alert = UIAlertController(title: "Don't miss out on events with free food!", message: "Enabling notifications allows us to notify you about events with free food coming up one day in advance.", preferredStyle: .alert)
-//        alert.addAction(UIAlertAction(title: "OK", style: .default, handler: { action in
-//            //run your function here
-            self.notificationAuthorization()
-//        }))
-//        self.window?.rootViewController?.present(alert, animated: true, completion: nil)
 
         return true
     }

--- a/EventsManager/AppDelegate.swift
+++ b/EventsManager/AppDelegate.swift
@@ -53,11 +53,19 @@ class AppDelegate: UIResponder, UIApplicationDelegate, UNUserNotificationCenterD
         UINavigationBar.appearance().largeTitleTextAttributes = [NSAttributedString.Key.font: UIFont(name: "SFProText-Bold", size: 32)!, NSAttributedString.Key.foregroundColor: UIColor(named: "primaryPink") ?? UIColor.red]
         window?.tintColor = UIColor(named: "primaryPink")
         
+
         //free food alert
         let alert = UIAlertController(title: "Don't miss out on events with free food!", message: "Enabling notifications allows us to notify you about events with free food coming up one day in advance.", preferredStyle: .alert)
-        alert.addAction(UIAlertAction(title: "OK", style: .default, handler: nil))
+        alert.addAction(UIAlertAction(title: "OK", style: .default, handler: { action in
+            //run your function here
+            self.notificationAuthorization()
+        }))
         self.window?.rootViewController?.present(alert, animated: true, completion: nil)
 
+        return true
+    }
+    
+    func notificationAuthorization() {
         //request notifications
         let notificationCenter = UNUserNotificationCenter.current()
         notificationCenter.delegate = self
@@ -72,19 +80,13 @@ class AppDelegate: UIResponder, UIApplicationDelegate, UNUserNotificationCenterD
                 ])
             }
         })
-
-        return true
     }
 
     //track notifications that have been clicked
     func userNotificationCenter(_ center: UNUserNotificationCenter, didReceive response: UNNotificationResponse, withCompletionHandler completionHandler: @escaping () -> Void) {
-
-        
             Analytics.logEvent("notificationClicked", parameters: [
                 "description": response.notification.request.content
             ])
-        
-
         completionHandler()
     }
 

--- a/EventsManager/AppDelegate.swift
+++ b/EventsManager/AppDelegate.swift
@@ -55,12 +55,12 @@ class AppDelegate: UIResponder, UIApplicationDelegate, UNUserNotificationCenterD
         
 
         //free food alert
-        let alert = UIAlertController(title: "Don't miss out on events with free food!", message: "Enabling notifications allows us to notify you about events with free food coming up one day in advance.", preferredStyle: .alert)
-        alert.addAction(UIAlertAction(title: "OK", style: .default, handler: { action in
-            //run your function here
+//        let alert = UIAlertController(title: "Don't miss out on events with free food!", message: "Enabling notifications allows us to notify you about events with free food coming up one day in advance.", preferredStyle: .alert)
+//        alert.addAction(UIAlertAction(title: "OK", style: .default, handler: { action in
+//            //run your function here
             self.notificationAuthorization()
-        }))
-        self.window?.rootViewController?.present(alert, animated: true, completion: nil)
+//        }))
+//        self.window?.rootViewController?.present(alert, animated: true, completion: nil)
 
         return true
     }

--- a/EventsManager/AppDelegate.swift
+++ b/EventsManager/AppDelegate.swift
@@ -52,6 +52,11 @@ class AppDelegate: UIResponder, UIApplicationDelegate, UNUserNotificationCenterD
         UINavigationBar.appearance().titleTextAttributes = [NSAttributedString.Key.font: UIFont(name: "SFProText-Bold", size: 19)!, NSAttributedString.Key.foregroundColor: UIColor(named: "primaryPink") ?? UIColor.red]
         UINavigationBar.appearance().largeTitleTextAttributes = [NSAttributedString.Key.font: UIFont(name: "SFProText-Bold", size: 32)!, NSAttributedString.Key.foregroundColor: UIColor(named: "primaryPink") ?? UIColor.red]
         window?.tintColor = UIColor(named: "primaryPink")
+        
+        //free food alert
+        let alert = UIAlertController(title: "Don't miss out on events with free food!", message: "Enabling notifications allows us to notify you about events with free food coming up one day in advance.", preferredStyle: .alert)
+        alert.addAction(UIAlertAction(title: "OK", style: .default, handler: nil))
+        self.window?.rootViewController?.present(alert, animated: true, completion: nil)
 
         //request notifications
         let notificationCenter = UNUserNotificationCenter.current()
@@ -66,7 +71,6 @@ class AppDelegate: UIResponder, UIApplicationDelegate, UNUserNotificationCenterD
                     "description": notification.request.content
                 ])
             }
-            
         })
 
         return true

--- a/EventsManager/Info.plist
+++ b/EventsManager/Info.plist
@@ -2,6 +2,8 @@
 <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
 <plist version="1.0">
 <dict>
+	<key>NSCalendarsUsageDescription</key>
+	<string>Bookmark events to add them to your apple calendar!</string>
 	<key>CFBundleDevelopmentRegion</key>
 	<string>$(DEVELOPMENT_LANGUAGE)</string>
 	<key>CFBundleDisplayName</key>

--- a/EventsManager/Localizable.strings
+++ b/EventsManager/Localizable.strings
@@ -40,6 +40,9 @@
 "notification-identifier" = "event_notification_";
 "notification-weekly-title" = "New events have been added to the app";
 "notification-weekly-body" =  "Check them out!";
+"free-food-notification-title" = "A new free food event is coming up";
+"free-food-notification-body" = " is happening tomorrow!";
+
 
 //Event List View
 "tool-bar-cancel-button" = "Cancel";

--- a/EventsManager/Localizable.strings
+++ b/EventsManager/Localizable.strings
@@ -121,7 +121,7 @@
 "onboarding-interact-title" = "Interact";
 "onboarding-interact-description" = "Choose some on-campus organizations that you would like to follow. ";
 "onboarding-no-orgs" = "No Organizations Yet";
-"on-bording-choose-3-to-continue" = "   Choose 3 to Continue   ";
+"on-bording-choose-3-to-continue" = "   Choose 2 to Continue   ";
 "on-bording-continue" = "   Continue   ";
 "onboarding-interest-title" = "Interest";
 "onboarding-interest-description" = "Let us know your interests. We’ll tailor your feed to include events you’ll be interested in.";

--- a/EventsManager/ViewControllers/EventsDiscoveryController.swift
+++ b/EventsManager/ViewControllers/EventsDiscoveryController.swift
@@ -49,7 +49,7 @@ class EventsDiscoveryController: UIViewController, UITableViewDelegate, UITableV
         preloadCells()
         scheduleNotification()
 
-        freeFoodEventNotifications()
+//        freeFoodEventNotifications()
 
         setup()
     }
@@ -143,14 +143,15 @@ class EventsDiscoveryController: UIViewController, UITableViewDelegate, UITableV
         dateComponents.calendar = Calendar.current
 
         //n is 7 and Sunday is represented by 1
-        dateComponents.weekday = 4  // Wednesday
+        dateComponents.weekday = 1  // Sunday
         dateComponents.hour = 15    // 3:00pm
         // Create the trigger as a repeating event.
         let trigger = UNCalendarNotificationTrigger(
                  dateMatching: dateComponents, repeats: true)
         // Create the request
-        let uuidString = UUID().uuidString
-        let request = UNNotificationRequest(identifier: uuidString,
+//        let uuidString = UUID().uuidString
+        let notificationIdentifier = "\(NSLocalizedString("notification-identifier", comment: ""))\(String(describing: dateComponents.weekOfMonth))"
+        let request = UNNotificationRequest(identifier: notificationIdentifier,
                     content: content, trigger: trigger)
 
         // Schedule the request with the system.
@@ -218,36 +219,36 @@ class EventsDiscoveryController: UIViewController, UITableViewDelegate, UITableV
     }
     
     //free food notifications
-    func freeFoodEventNotifications() {
-        for event in events {
-            for tag in event.eventTags {
-                if AppData.getTag(by: tag, startLoading: {_ in }, endLoading: {}, noConnection: {}, updateData: false).name == "Free Food" {
-                    let center = UNUserNotificationCenter.current()
-                    if let user = UserData.getLoggedInUser() {
-                        if user.reminderEnabled {
-                            let content = UNMutableNotificationContent()
-                            content.title = NSLocalizedString("free-food-notification-title", comment: "")
-                            content.body = "\(event.eventName)\(NSLocalizedString("free-food-notification-body", comment: ""))"
-                            content.sound = .default
-                            let minutesBeforeEvent = 1440
-                            let minuteComp = DateComponents(minute: -minutesBeforeEvent)
-                            let remindDate = Calendar.current.date(byAdding: minuteComp, to: event.startTime)
-                            if let remindDate = remindDate {
-                                let triggerDate = Calendar.current.dateComponents([.year, .month, .day, .hour, .minute, .second ], from: remindDate)
-                                let trigger = UNCalendarNotificationTrigger(dateMatching: triggerDate,
-                                                                            repeats: false)
-                                let notificationIdentifier = "\(NSLocalizedString("notification-identifier", comment: ""))\(event.id)"
-                                let request = UNNotificationRequest(identifier: notificationIdentifier,
-                                                                    content: content, trigger: trigger)
-                                center.add(request, withCompletionHandler: { (_) in
-                                })
-                            }
-                        }
-                    }
-                }
-            }
-        }
-    }
+//    func freeFoodEventNotifications() {
+//        for event in events {
+//            for tag in event.eventTags {
+//                if AppData.getTag(by: tag, startLoading: {_ in }, endLoading: {}, noConnection: {}, updateData: false).name == "Free Food" {
+//                    let center = UNUserNotificationCenter.current()
+//                    if let user = UserData.getLoggedInUser() {
+//                        if user.reminderEnabled {
+//                            let content = UNMutableNotificationContent()
+//                            content.title = NSLocalizedString("free-food-notification-title", comment: "")
+//                            content.body = "\(event.eventName)\(NSLocalizedString("free-food-notification-body", comment: ""))"
+//                            content.sound = .default
+//                            let minutesBeforeEvent = 1440
+//                            let minuteComp = DateComponents(minute: -minutesBeforeEvent)
+//                            let remindDate = Calendar.current.date(byAdding: minuteComp, to: event.startTime)
+//                            if let remindDate = remindDate {
+//                                let triggerDate = Calendar.current.dateComponents([.year, .month, .day, .hour, .minute, .second ], from: remindDate)
+//                                let trigger = UNCalendarNotificationTrigger(dateMatching: triggerDate,
+//                                                                            repeats: false)
+//                                let notificationIdentifier = "\(NSLocalizedString("notification-identifier", comment: ""))\(event.id)"
+//                                let request = UNNotificationRequest(identifier: notificationIdentifier,
+//                                                                    content: content, trigger: trigger)
+//                                center.add(request, withCompletionHandler: { (_) in
+//                                })
+//                            }
+//                        }
+//                    }
+//                }
+//            }
+//        }
+//    }
 
     func numberOfSections(in tableView: UITableView) -> Int {
         return 4

--- a/EventsManager/ViewControllers/EventsDiscoveryController.swift
+++ b/EventsManager/ViewControllers/EventsDiscoveryController.swift
@@ -217,38 +217,37 @@ class EventsDiscoveryController: UIViewController, UITableViewDelegate, UITableV
     @objc func searchButtonPressed(_ sender: UIBarButtonItem) {
         navigationController?.pushViewController(EventsSearchViewController(), animated: true)
     }
-    
     //free food notifications
-//    func freeFoodEventNotifications() {
-//        for event in events {
-//            for tag in event.eventTags {
-//                if AppData.getTag(by: tag, startLoading: {_ in }, endLoading: {}, noConnection: {}, updateData: false).name == "Free Food" {
-//                    let center = UNUserNotificationCenter.current()
-//                    if let user = UserData.getLoggedInUser() {
-//                        if user.reminderEnabled {
-//                            let content = UNMutableNotificationContent()
-//                            content.title = NSLocalizedString("free-food-notification-title", comment: "")
-//                            content.body = "\(event.eventName)\(NSLocalizedString("free-food-notification-body", comment: ""))"
-//                            content.sound = .default
-//                            let minutesBeforeEvent = 1440
-//                            let minuteComp = DateComponents(minute: -minutesBeforeEvent)
-//                            let remindDate = Calendar.current.date(byAdding: minuteComp, to: event.startTime)
-//                            if let remindDate = remindDate {
-//                                let triggerDate = Calendar.current.dateComponents([.year, .month, .day, .hour, .minute, .second ], from: remindDate)
-//                                let trigger = UNCalendarNotificationTrigger(dateMatching: triggerDate,
-//                                                                            repeats: false)
-//                                let notificationIdentifier = "\(NSLocalizedString("notification-identifier", comment: ""))\(event.id)"
-//                                let request = UNNotificationRequest(identifier: notificationIdentifier,
-//                                                                    content: content, trigger: trigger)
-//                                center.add(request, withCompletionHandler: { (_) in
-//                                })
-//                            }
-//                        }
-//                    }
-//                }
-//            }
-//        }
-//    }
+    func freeFoodEventNotifications() {
+        for event in events {
+            for tag in event.eventTags {
+                if AppData.getTag(by: tag, startLoading: {_ in }, endLoading: {}, noConnection: {}, updateData: false).name == "Free Food" {
+                    let center = UNUserNotificationCenter.current()
+                    if let user = UserData.getLoggedInUser() {
+                        if user.reminderEnabled {
+                            let content = UNMutableNotificationContent()
+                            content.title = NSLocalizedString("free-food-notification-title", comment: "")
+                            content.body = "\(event.eventName)\(NSLocalizedString("free-food-notification-body", comment: ""))"
+                            content.sound = .default
+                            let minutesBeforeEvent = 1440
+                            let minuteComp = DateComponents(minute: -minutesBeforeEvent)
+                            let remindDate = Calendar.current.date(byAdding: minuteComp, to: event.startTime)
+                            if let remindDate = remindDate {
+                                let triggerDate = Calendar.current.dateComponents([.year, .month, .day, .hour, .minute, .second ], from: remindDate)
+                                let trigger = UNCalendarNotificationTrigger(dateMatching: triggerDate,
+                                                                            repeats: false)
+                                let notificationIdentifier = "\(NSLocalizedString("notification-identifier", comment: ""))\(event.id)"
+                                let request = UNNotificationRequest(identifier: notificationIdentifier,
+                                                                    content: content, trigger: trigger)
+                                center.add(request, withCompletionHandler: { (_) in
+                                })
+                            }
+                        }
+                    }
+                }
+            }
+        }
+    }
 
     func numberOfSections(in tableView: UITableView) -> Int {
         return 4

--- a/EventsManager/ViewControllers/OnBoardingViewController.swift
+++ b/EventsManager/ViewControllers/OnBoardingViewController.swift
@@ -11,7 +11,7 @@ import Firebase
 class OnBoardingViewController: UIViewController, UITableViewDelegate, UITableViewDataSource, UISearchControllerDelegate, UISearchResultsUpdating {
 
     //constants
-    let minimumSelectionCount = 3
+    let minimumSelectionCount = 2
     let navTitleFontSize: CGFloat = 25
     let navSubtitleFontSize: CGFloat = 15
     let titleToTopSpacing: CGFloat = 10

--- a/EventsManager/ViewControllers/OnBoardingViewController.swift
+++ b/EventsManager/ViewControllers/OnBoardingViewController.swift
@@ -11,7 +11,7 @@ import Firebase
 class OnBoardingViewController: UIViewController, UITableViewDelegate, UITableViewDataSource, UISearchControllerDelegate, UISearchResultsUpdating {
 
     //constants
-    let minimumSelectionCount = 2
+    let minimumSelectionCount = 1
     let navTitleFontSize: CGFloat = 25
     let navSubtitleFontSize: CGFloat = 15
     let titleToTopSpacing: CGFloat = 10


### PR DESCRIPTION
Added an alert explaining the rationale behind enabling notifications, and added notifications for events with the free food tag a day in advance.

Also added functionality to add events to the user's apple calendar when bookmarking events. When the user 'unbookmarks' an event, the event is removed from their apple calendar.